### PR TITLE
Add Tallahassee Dream Defenders

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -72,6 +72,9 @@ title: "List of Bail Funds for Protestors"
 * [(F)empower Community Bond Fund](https://www.paypal.me/freethemall)
 * [Florida LGBTQ Freedom Fund](https://www.lgbtqfund.org/donate-1)
 
+### Tallahassee
+* [Tallahassee Dream Defenders Bail Fund](https://cash.app/$FreeFloridaBailFund)
+
 ## Georgia
 ### Atlanta
 * [Atlanta Solidarity Fund](http://atlsolidarity.org/)


### PR DESCRIPTION
A fund sponsored by Tallahassee Dream Defenders, posted on their [Instagram](https://www.instagram.com/p/CA3ClK_Fgym/).
Also being promoted by several other groups in Tallahassee, such as [FSU SJP](https://twitter.com/FSU4Palestine/status/1267241320336306176?s=20).