### PR TITLE
Propose adding Rhode Island - AMOR Bond Fund - PrYSM

### DIFF
--- a/_data/regions/rhodeisland.yaml
+++ b/_data/regions/rhodeisland.yaml
@@ -3,5 +3,8 @@
   latitude: 41.5801
   longtitude: 71.4774
   bailfunds:
+    - name: AMOR Bond Fund
+      link: https://secure.actblue.com/donate/freethemall
+      note: Providence Youth Student Movement (PrYSM) is the fiscal sponsor and one of the backbone organizations for AMOR. All funds raised will go directly to support AMOR's work
     - name: FANG Community Bail Fund
       link: https://www.gofundme.com/f/fangbailfund


### PR DESCRIPTION
I came across bailfunds.github.io while researching FANG Community Bail Fund in Rhode Island. I'm from Rhode Island and I happened to click on this link on your github page: https://www.communityjusticeexchange.org/nbfn-directory
Through that link I got curios and checked to see if there were other bail funds in Rhode Island. I found AMOR Bond Fund, which I'm proposing to add through this PR. I don't know a lot about bail funds, but I'm interested in supporting and thought your idea to provide this information through a git repository was excellent. 